### PR TITLE
[Bugfix] Handle INVALID_EMAIL error when login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.mewcom</groupId>
   <artifactId>backend</artifactId>
-  <version>0.1.0-3</version>
+  <version>0.1.0-4-SNAPSHOT</version>
   <name>mewcom-backend</name>
   <description>mewcom-backend</description>
 

--- a/src/main/java/com/mewcom/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/mewcom/backend/config/SwaggerConfig.java
@@ -38,7 +38,7 @@ public class SwaggerConfig implements WebMvcConfigurer {
     private ApiInfo buildApiInfo () {
         return new ApiInfoBuilder()
             .title("Mewcom Backend Service")
-            .version("0.1.0-3-SNAPSHOT")
+            .version("0.1.0-4-SNAPSHOT")
             .build();
     }
 }

--- a/src/main/java/com/mewcom/backend/outbound/decoder/GoogleIdentityToolkitErrorDecoder.java
+++ b/src/main/java/com/mewcom/backend/outbound/decoder/GoogleIdentityToolkitErrorDecoder.java
@@ -28,7 +28,9 @@ public class GoogleIdentityToolkitErrorDecoder implements ErrorDecoder {
               GoogleIdentityToolkitErrorResponse.class);
       GoogleIdentityToolkitErrorResponse.Error responseBodyError = responseBody.getError();
       if (responseBodyError.getCode() == HttpStatus.BAD_REQUEST.value()) {
-        if (responseBodyError.getMessage().equals(OutboundErrorMessage.EMAIL_NOT_FOUND)) {
+        if (responseBodyError.getMessage().equals(OutboundErrorMessage.INVALID_EMAIL)) {
+          return new BaseException(ErrorCode.USER_EMAIL_INVALID);
+        } else if (responseBodyError.getMessage().equals(OutboundErrorMessage.EMAIL_NOT_FOUND)) {
           return new BaseException(ErrorCode.USER_EMAIL_NOT_FOUND);
         } else if (responseBodyError.getMessage().equals(OutboundErrorMessage.INVALID_PASSWORD)) {
           return new BaseException(ErrorCode.USER_PASSWORD_INVALID);

--- a/src/main/java/com/mewcom/backend/outbound/model/constant/OutboundErrorMessage.java
+++ b/src/main/java/com/mewcom/backend/outbound/model/constant/OutboundErrorMessage.java
@@ -2,6 +2,8 @@ package com.mewcom.backend.outbound.model.constant;
 
 public class OutboundErrorMessage {
 
+  public static final String INVALID_EMAIL = "INVALID_EMAIL";
+
   public static final String EMAIL_NOT_FOUND = "EMAIL_NOT_FOUND";
 
   public static final String INVALID_PASSWORD = "INVALID_PASSWORD";


### PR DESCRIPTION
Current:
 - Request with invalid email password (e.g "email": "a") will throw unspecified error.

Expected:
 - Still throw error, but instead shows that email requested is invalid.

Cause:
 - Google API used to verify credentials throws INVALID_EMAIL error when email format requested is invalid.
 - Currently app can only handle EMAIL_NOT_FOUND & INVALID_PASSWORD error, hence the unspecified error message.
 
Fix Details:
 - Handle INVALID_EMAIL error when calling google's api.